### PR TITLE
Fix Spree issue#6035

### DIFF
--- a/core/lib/spree/core/importer/product.rb
+++ b/core/lib/spree/core/importer/product.rb
@@ -40,6 +40,7 @@ module Spree
             set_up_options
           end
 
+          product.touch
           product
         end
 


### PR DESCRIPTION
https://github.com/spree/spree/issues/6035

Call ```product.touch``` at the end of ```Spree::Core::Importer::Product#update``` to

1. Modify the ```updated_at``` field of the product so that key-based caching can pick up new changes.
2. Invoke the ```after_touch``` callback in ```Spree::Product``` to touch the taxons of the product.